### PR TITLE
if DESTALINATOR_DEBUG environment variable is set to something, outpu…

### DIFF
--- a/destalinator.py
+++ b/destalinator.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 import datetime
+import os
 import sys
 import time
 
@@ -16,6 +17,7 @@ class Destalinator(object):
     warning_text_fname = "warning.txt"
     earliest_archive_date = "2016-01-28"  # Do not archive channels prior to this date
     log_channel = "destalinator-log"
+    debug_environment_variable = "DESTALINATOR_DEBUG"
 
     ignore_users = ["USLACKBOT"]
 
@@ -33,6 +35,7 @@ class Destalinator(object):
         self.closure_text = self.get_content(self.closure_text_fname)
         self.warning_text = self.get_content(self.warning_text_fname)
         self.slackbot = slackbot
+        self.debug_flag = os.getenv(self.debug_environment_variable)
 
     def get_content(self, fname):
         """
@@ -192,7 +195,10 @@ class Destalinator(object):
 
     def debug(self, message):
         message = "DEBUG: " + message
-        self.log(message)
+        if self.debug_flag:
+            print message
+        else:
+            self.log(message)
 
     def warning(self, message):
         message = "WARNING: " + message


### PR DESCRIPTION
…t debugging content to stdout instead of to Slack.  Once this goes in, daily debug output will disappear