### PR TITLE
Move more settings to config file

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,15 +1,41 @@
 # Name of your Slack (Deprecated in favour of the SLACK_NAME env var)
 slack_name: rands-leadership
+
 # Name of environmental variable holding a valid Slackbot API token
 slackbot_api_token_env_varname: SB_TOKEN
+
 # Name of environmental variable holding a valid general-purpose API token
 api_token_env_varname: API_TOKEN
+
+# Name of environmental variable determining whether output debug mode is enabled
+output_debug_env_varname: DESTALINATOR_SLACK_VERBOSE
+
 # Days of silence before we warn a channel it's going to be archived
 warn_threshold: 30
+
 # Days of silence before we auto-archive a channel
 archive_threshold: 60
-earliest_archive_date: "2016-01-28"  # Do not archive before this date
+
+# Do not archive before this date
+earliest_archive_date: "2016-01-28"
+
 # Where should we announce new channels?
 announce_channel: "zmeta-new-channels"
+
 # Where do we send control messages?
 control_channel: "zmeta-control"
+
+# Where to send destalinator debug logs
+log_channel: "destalinator-log"
+
+# Channels to ignore when archiving (i.e. they can be silent and not get archived)
+ignore_channels:
+  - destalinator-log
+
+# Regular expression patterns for additional channels to ignore during archiving
+ignore_channel_patterns:
+  - ^zmeta-
+
+# Users to ignore when considering if a channel is stale
+ignore_users:
+  - USLACKBOT

--- a/flagger.py
+++ b/flagger.py
@@ -24,7 +24,7 @@ class Flagger(executor.Executor):
 
         def initialize_control(self):
             """
-            sets up known control configuration based on #zmeta-control messages
+            sets up known control configuration based on control channel messages
             """
             channel = config.control_channel
             cid = self.slacker.get_channelid(channel)

--- a/slacker.py
+++ b/slacker.py
@@ -87,7 +87,7 @@ class Slacker(object):
     def get_channels(self, exclude_archived=True):
         """
         return a {channel_name: channel_id} dictionary
-        if exclude_arhived (default: True), only shows non-archived channels
+        if exclude_archived (default: True), only shows non-archived channels
         """
         channels = self.get_all_channel_objects(exclude_archived=exclude_archived)
         self.channels_by_id = {x['id']: x['name'] for x in channels}
@@ -127,7 +127,7 @@ class Slacker(object):
     def get_all_channel_objects(self, exclude_archived=True):
         """
         return all channels
-        if exclude_arhived (default: True), only shows non-archived channels
+        if exclude_archived (default: True), only shows non-archived channels
         """
 
         url_template = self.url + "channels.list?exclude_archived={}&token={}"


### PR DESCRIPTION
Some lingering items were still stored as class variables inside of `Destalinator()`. Now they live in `configuration.yaml`.