### PR TITLE
Allow other message subtypes to count as activity

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -39,3 +39,7 @@ ignore_channel_patterns:
 # Users to ignore when considering if a channel is stale
 ignore_users:
   - USLACKBOT
+
+# Which message subtypes (other than "none") count as activity?
+included_subtypes:
+  - bot_message

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -41,7 +41,6 @@ ignore_users:
   - USLACKBOT
 
 # Which message subtypes count as activity?
-# "None" means the message was typed by a human. You probably want to keep it.
+# "None" means the message was typed by a human and is included by default.
 included_subtypes:
-  - None
   - bot_message

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -40,6 +40,8 @@ ignore_channel_patterns:
 ignore_users:
   - USLACKBOT
 
-# Which message subtypes (other than "none") count as activity?
+# Which message subtypes count as activity?
+# "None" means the message was typed by a human. You probably want to keep it.
 included_subtypes:
+  - None
   - bot_message

--- a/destalinator.py
+++ b/destalinator.py
@@ -124,7 +124,7 @@ class Destalinator(object):
         messages = self.slacker.get_messages_in_time_range(oldest, cid)
         # print "now is {}, oldest is {}, diff is {}".format(now, oldest, now - oldest)
         # print "messages for {} are {}".format(cid, messages)
-        messages = [x for x in messages if x.get("subtype") is None]
+        messages = [x for x in messages if (x.get("subtype") is None or x.get("subtype") in self.config.included_subtypes)]
         if cid not in self.cache:
             self.cache[cid] = {}
         self.cache[cid][oldest] = messages
@@ -150,8 +150,8 @@ class Destalinator(object):
             return False
         self.slackbot.say(channel_name, self.warning_text)
         self.action("Warned {}".format(channel_name))
-        return True
         # print "warned {}".format(channel_name)
+        return True
 
     def log(self, message):
         timestamp = time.strftime("%H:%M:%S: ", time.localtime())

--- a/destalinator.py
+++ b/destalinator.py
@@ -124,7 +124,7 @@ class Destalinator(object):
         messages = self.slacker.get_messages_in_time_range(oldest, cid)
         # print "now is {}, oldest is {}, diff is {}".format(now, oldest, now - oldest)
         # print "messages for {} are {}".format(cid, messages)
-        messages = [x for x in messages if x.get("subtype") in self.config.included_subtypes]
+        messages = [x for x in messages if (x.get("subtype") is None or x.get("subtype") in self.config.included_subtypes)]
         if cid not in self.cache:
             self.cache[cid] = {}
         self.cache[cid][oldest] = messages

--- a/destalinator.py
+++ b/destalinator.py
@@ -124,7 +124,7 @@ class Destalinator(object):
         messages = self.slacker.get_messages_in_time_range(oldest, cid)
         # print "now is {}, oldest is {}, diff is {}".format(now, oldest, now - oldest)
         # print "messages for {} are {}".format(cid, messages)
-        messages = [x for x in messages if (x.get("subtype") is None or x.get("subtype") in self.config.included_subtypes)]
+        messages = [x for x in messages if x.get("subtype") in self.config.included_subtypes]
         if cid not in self.cache:
             self.cache[cid] = {}
         self.cache[cid][oldest] = messages


### PR DESCRIPTION
This change adds a configurable option to count other message subtypes (such as those from bots) as legit activity. It's common to have logging or alert channels without any human discussion, but with lots of (potentially important) messages from bots.