### PR TITLE
Cleanup and tests and post-as-bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,7 @@ If you run into rate limits on your test token, you may need to set up a Slack A
 Destalinator can be chatty and make potentially big changes to a Slack team (by warning or archiving a large amount of channels), especially when first installed.
 
 To minimize the risk of making a mistake, Destalinator will run in a dry-run mode unless the `DESTALINATOR_ACTIVATED` environment variable exists. Set it to any non-empty value and Destalinator is "active." If you want to remain in dry-run mode, ensure this variable is unset/does not exist.
+
+#### `DESTALINATOR_LOG_LEVEL`
+
+Tune your preferred log level for server logs or local debugging. Does not affect the ENV var specified by `output_debug_env_varname`.

--- a/announcer.py
+++ b/announcer.py
@@ -36,7 +36,7 @@ class Announcer(executor.Executor):
                 if self.slacker.channel_exists(config.announce_channel):
                     self.sb.say(config.announce_channel, m)
                 else:
-                    self.ds.warning("Attempted to announce in {}, but channel does not exist.".format(config.announce_channel))
+                    self.ds.logger.warning("Attempted to announce in %s, but channel does not exist.", config.announce_channel)
             print("ANNOUNCE: {}".format(m))
 
 

--- a/destalinator.py
+++ b/destalinator.py
@@ -7,11 +7,11 @@ import time
 import logging
 import json
 import requests
-import codecs
 import sys
 
 import config
 import slackbot
+import utils
 
 
 # An arbitrary past date, as a default value for the earliest archive date
@@ -29,8 +29,8 @@ class Destalinator(object):
         slackbot should be an initialized slackbot.Slackbot() object
         activated is a boolean indicating whether destalinator should do dry runs or real runs
         """
-        self.closure_text = self.get_content(self.closure_text_fname)
-        self.warning_text = self.get_content(self.warning_text_fname)
+        self.closure_text = utils.get_local_file_content(self.closure_text_fname)
+        self.warning_text = utils.get_local_file_content(self.warning_text_fname)
         self.slacker = slacker
         self.slackbot = slackbot
         self.user = os.getenv("USER")

--- a/destalinator.py
+++ b/destalinator.py
@@ -227,7 +227,7 @@ class Destalinator(object):
 
         messages = self.get_messages(channel_name, days)
         texts = [x.get("text").strip() for x in messages if x.get("text")]
-        if self.add_slack_channel_markup(self.warning_text) in texts and not force_warn:
+        if not force_warn and self.add_slack_channel_markup(self.warning_text) in texts:
             self.debug("Not warning #{} because we found a prior warning".format(channel_name))
             return False
 

--- a/destalinator.py
+++ b/destalinator.py
@@ -25,6 +25,7 @@ class Destalinator(object):
         """
         slacker is a Slacker() object
         slackbot should be an initialized slackbot.Slackbot() object
+        activated is a boolean indicating whether destalinator should do dry runs or real runs
         """
         self.closure_text = self.get_content(self.closure_text_fname)
         self.warning_text = self.get_content(self.warning_text_fname)
@@ -47,6 +48,12 @@ class Destalinator(object):
         self.cache = {}
         self.now = int(time.time())
 
+    ## utility & data fetch methods
+
+    def action(self, message):
+        message = "*ACTION: " + message + "*"
+        self.log(message)
+
     def add_slack_channel_markup_item(self, item):
         return self.slacker.add_channel_markup(item.group(1))
 
@@ -54,80 +61,71 @@ class Destalinator(object):
         marked_up = re.sub(r"\#([a-z0-9_-]+)", self.add_slack_channel_markup_item, text)
         return marked_up
 
-    def get_content(self, fname):
-        """
-        read fname into unicode text blob, return unicode text blob
-        """
-        f = codecs.open(fname, encoding='utf-8')
-        ret = f.read().strip()
-        f.close()
-        return ret
-
-    def safe_archive(self, channel_name):
-        """
-        Arhives channel if today's date is after self.earliest_archive_date
-        and if channel does not only contain SCGs (Single-Channel Guests)
-        """
-
-        if self.slacker.channel_has_only_restricted_members(channel_name):
-            message = "Would have archived {} but it contains restricted users".format(channel_name)
-            self.debug(message)
-            return
-
-        today = datetime.date.today()
-        if today >= self.earliest_archive_date:
-            self.action("Archiving channel {}".format(channel_name))
-            self.archive(channel_name)
-        else:
-            message = "Would have archived {} but it's not yet {}"
-            message = message.format(channel_name, self.earliest_archive_date)
-            self.debug(message)
-
-    def archive(self, channel_name):
-        """
-        Archives the given channel name.  Returns the response content
-        """
-        if self.ignore_channel(channel_name):
-            self.debug("Not archiving {} because it's in ignore_channels".format(channel_name))
-            return
-
-        if self.destalinator_activated:
-            self.slackbot.say(channel_name, self.closure_text)
-            self.debug("Telling channel {}: {}".format(channel_name, self.closure_text))
-            members = self.slacker.get_channel_member_names(channel_name)
-            say = "Members at archiving are {}".format(", ".join(members))
-            self.slackbot.say(channel_name, say)
-            self.debug("Telling channel {}: {}".format(channel_name, say))
-            payload = self.slacker.archive(channel_name)
-
-            if payload['ok']:
-                self.debug("Payload: {}".format(json.dumps(payload, indent=4)))
-                self.debug("Archived {}".format(channel_name))
-            else:
-                error = payload.get('error', '!! No error found in payload %s !!' % payload)
-                self.debug("Failed to archive {channel_name}: {error}. See https://api.slack.com/methods/channels.archive for more context.".format(channel_name=channel_name, error=error))
-
-            return payload
-
     def channel_minimum_age(self, channel_name, days):
-        """
-        returns True/False depending on whether channel_name is at least DAYS old
-        """
+        """Return True if channel represented by `channel_name` is at least `days` old, otherwise False."""
         info = self.slacker.get_channel_info(channel_name)
         age = info['age']
         age = age / 86400
         return age > days
 
+    def debug(self, message):
+        message = "DEBUG: " + message
+        if self.output_debug_to_slack_flag:
+            self.log(message)
+
+    def get_messages(self, channel_name, days):
+        """Return `days` worth of messages for channel `channel_name`. Caches messages per channel & days."""
+        oldest = self.now - days * 86400
+        cid = self.slacker.get_channelid(channel_name)
+
+        if oldest in self.cache.get(cid, {}):
+            self.debug("Returning {} cached messages for #{} over {} days".format(len(self.cache[cid][oldest]), channel_name, days))
+            return self.cache[cid][oldest]
+
+        messages = self.slacker.get_messages_in_time_range(oldest, cid)
+        self.debug("Fetched {} messages for #{} over {} days".format(len(messages), channel_name, days))
+
+        messages = [x for x in messages if (x.get("subtype") is None or x.get("subtype") in self.config.included_subtypes)]
+
+        if cid not in self.cache:
+            self.cache[cid] = {}
+        self.cache[cid][oldest] = messages
+
+        return messages
+
+    def get_stale_channels(self, days):
+        ret = []
+        for channel in sorted(self.slacker.channels_by_name.keys()):
+            if self.stale(channel, days):
+                ret.append(channel)
+        self.debug("{} channels quiet for {} days: {}".format(len(ret), days, ret))
+        return ret
+
+    def ignore_channel(self, channel_name):
+        if channel_name in self.config.ignore_channels:
+            return True
+        for pat in self.config.ignore_channel_patterns:
+            if re.match(pat, channel_name):
+                return True
+        return False
+
+    def log(self, message):
+        timestamp = time.strftime("%H:%M:%S: ", time.localtime())
+        message = timestamp + " ({}) ".format(self.user) + message
+        self.slackbot.say(self.config.log_channel, message)
+
     def stale(self, channel_name, days):
         """
-        returns True/False whether the channel is stale.  Definition of stale is
-        no messages in the last DAYS days which are not from config.ignore_users
+        Return True if channel represented by `channel_name` is stale.
+        Definition of stale is: no messages in the last `days` which are not from config.ignore_users.
         """
         minimum_age = self.channel_minimum_age(channel_name, days)
         if not minimum_age:
-            # self.debug("Not checking if {} is stale -- it's too new".format(channel_name))
+            self.debug("Channel #{} is not yet of minimum_age; skipping stale messages check".format(channel_name))
             return False
+
         messages = self.get_messages(channel_name, days)
+
         # return True (stale) if none of the messages match the criteria below
         return not any(
             # the message is not from an ignored user
@@ -141,42 +139,74 @@ class Destalinator(object):
             for x in messages
         )
 
-    def get_messages(self, cname, days):
+    ## channel actions
+
+    def archive(self, channel_name):
+        """Archive the given channel name, returning the Slack API response as a JSON string."""
+        if self.ignore_channel(channel_name):
+            self.debug("Not archiving #{} because it's in ignore_channels".format(channel_name))
+            return
+
+        if self.destalinator_activated:
+            self.debug("Announcing channel closure in #{}".format(channel_name))
+            self.slackbot.say(channel_name, self.closure_text)
+
+            members = self.slacker.get_channel_member_names(channel_name)
+            say = "Members at archiving are {}".format(", ".join(sorted(members)))
+            self.debug("Telling channel #{}: {}".format(channel_name, say))
+            self.slackbot.say(channel_name, say)
+
+            payload = self.slacker.archive(channel_name)
+            if payload['ok']:
+                self.debug("Slack API response to archive: {}".format(json.dumps(payload, indent=4)))
+            else:
+                error = payload.get('error', '!! No error found in payload %s !!' % payload)
+
+            return payload
+
+    def safe_archive(self, channel_name):
         """
-        returns messages for channel cname, in the last days days
+        Archive channel if today's date is after `self.earliest_archive_date`
+        and if channel does not only contain single-channel guests.
         """
-        oldest = self.now - days * 86400
-        cid = self.slacker.get_channelid(cname)
-        if oldest in self.cache.get(cid, {}):
-            return self.cache[cid][oldest]
-        messages = self.slacker.get_messages_in_time_range(oldest, cid)
-        # print "now is {}, oldest is {}, diff is {}".format(now, oldest, now - oldest)
-        # print "messages for {} are {}".format(cid, messages)
-        messages = [x for x in messages if (x.get("subtype") is None or x.get("subtype") in self.config.included_subtypes)]
-        if cid not in self.cache:
-            self.cache[cid] = {}
-        self.cache[cid][oldest] = messages
-        # kprint "After filtering, messages are {}".format(messages)
-        return messages
+
+        if self.slacker.channel_has_only_restricted_members(channel_name):
+            self.debug("Would have archived #{} but it contains only restricted users".format(channel_name))
+            return
+
+        today = datetime.date.today()
+        if today >= self.earliest_archive_date:
+            self.action("Archiving channel #{}".format(channel_name))
+            self.archive(channel_name)
+        else:
+            self.debug("Would have archived #{} but it's not yet {}".format(channel_name, self.earliest_archive_date))
+
+    def safe_archive_all(self, days):
+        """Safe archives all channels stale longer than `days`."""
+        self.action("Safe-archiving all channels stale for more than {} days".format(days))
+        for channel in sorted(self.slacker.channels_by_name.keys()):
+            if self.ignore_channel(channel):
+                self.debug("Not archiving #{} because it's in ignore_channels".format(channel))
+                continue
+            if self.stale(channel, days):
+                self.debug("Attempting to safe-archive #{}".format(channel))
+                self.safe_archive(channel)
 
     def warn(self, channel_name, days, force_warn=False):
         """
-        send warning text to channel_name, if it has not been sent already
-        in the last DAYS days
-        if force_warn, will warn even if we have before
-        returns True/False whether or not we actually warned
+        Send warning text to channel_name, if it has not been sent already in the last `days`.
+        Using `force_warn=True` will warn even if a previous warning exists.
+        Return True if we actually warned, otherwise False.
         """
         if self.slacker.channel_has_only_restricted_members(channel_name):
-            message = "Would have warned {} but it contains restricted users".format(channel_name)
-            self.debug(message)
+            self.debug("Would have warned #{} but it contains only restricted users".format(channel_name))
             return False
 
         if self.ignore_channel(channel_name):
-            self.debug("Not warning {} because it's in ignore_channels".format(channel_name))
+            self.debug("Not warning #{} because it's in ignore_channels".format(channel_name))
             return False
 
         messages = self.get_messages(channel_name, days)
-        # print "messages for {}: {}".format(channel_name, messages)
         texts = [x.get("text").strip() for x in messages if x.get("text")]
         if self.add_slack_channel_markup(self.warning_text) in texts and not force_warn:
             # nothing to do
@@ -186,48 +216,8 @@ class Destalinator(object):
             self.slackbot.say(channel_name, self.warning_text)
         self.action("Warned {}".format(channel_name))
         # print "warned {}".format(channel_name)
+
         return True
-
-    def log(self, message):
-        timestamp = time.strftime("%H:%M:%S: ", time.localtime())
-        message = timestamp + " ({}) ".format(self.user) + message
-        self.slackbot.say(self.config.log_channel, message)
-
-    def action(self, message):
-        message = "*ACTION: " + message + "*"
-        self.log(message)
-
-    def debug(self, message):
-        message = "DEBUG: " + message
-        if self.output_debug_to_slack_flag:
-            self.log(message)
-        else:
-            print(message)
-
-    def warning(self, message):
-        message = "WARNING: " + message
-        self.log(message)
-
-    def safe_archive_all(self, days):
-        """
-        Safe-archives all channels stale longer than DAYS days
-        """
-        self.action("Safe-archiving all channels stale for more than {} days".format(days))
-        for channel in sorted(self.slacker.channels_by_name.keys()):
-            if self.ignore_channel(channel):
-                self.debug("Not archiving {} because it's in ignore_channels".format(channel))
-                continue
-            if self.stale(channel, days):
-                # self.debug("Attempting to safe-archive {}".format(channel))
-                self.safe_archive(channel)
-
-    def ignore_channel(self, channel_name):
-        if channel_name in self.config.ignore_channels:
-            return True
-        for pat in self.config.ignore_channel_patterns:
-            if re.match(pat, channel_name):
-                return True
-        return False
 
     def warn_all(self, days, force_warn=False):
         """
@@ -240,7 +230,7 @@ class Destalinator(object):
             m += "DESTALINATOR_ACTIVATED environment variable."
             self.log(m)
         self.action("Warning all channels stale for more than {} days".format(days))
-        # for channel in ["austin"]:
+
         stale = []
         for channel in sorted(self.slacker.channels_by_name.keys()):
             if self.ignore_channel(channel):
@@ -250,7 +240,6 @@ class Destalinator(object):
                 if self.warn(channel, days, force_warn):
                     stale.append(channel)
         if stale:
-
             self.debug("Notifying #{} of warned channels".format(self.config.general_message_channel))
             self.warn_in_general(stale)
 
@@ -272,12 +261,3 @@ class Destalinator(object):
         if self.destalinator_activated:
             self.slackbot.say(self.config.general_message_channel, message)
         self.debug("Notified #{} with: {}".format(self.config.general_message_channel, message))
-
-
-    def get_stale_channels(self, days):
-        ret = []
-        for channel in sorted(self.slacker.channels_by_name.keys()):
-            if self.stale(channel, days):
-                ret.append(channel)
-        self.debug("{} channels quiet for {} days: {}".format(len(ret), days, ret))
-        return ret

--- a/destalinator.py
+++ b/destalinator.py
@@ -124,7 +124,7 @@ class Destalinator(object):
     def log(self, message):
         timestamp = time.strftime("%H:%M:%S: ", time.localtime())
         message = timestamp + " ({}) ".format(self.user) + message
-        self.slackbot.say(self.config.log_channel, message)
+        self.slacker.post_message(self.config.log_channel, message, message_type='log')
 
     def set_up_logger(self, logger, log_level_env_var=None, log_to_slack_env_var=None, log_channel=None, default_level='INFO'):
         logger.setLevel(getattr(logging, os.getenv(log_level_env_var, default_level).upper(), getattr(logging, default_level)))
@@ -167,12 +167,12 @@ class Destalinator(object):
 
         if self.destalinator_activated:
             self.debug("Announcing channel closure in #{}".format(channel_name))
-            self.slackbot.say(channel_name, self.closure_text)
+            self.slacker.post_message(channel_name, self.closure_text, message_type='channel_archive')
 
             members = self.slacker.get_channel_member_names(channel_name)
             say = "Members at archiving are {}".format(", ".join(sorted(members)))
             self.debug("Telling channel #{}: {}".format(channel_name, say))
-            self.slackbot.say(channel_name, say)
+            self.slacker.post_message(channel_name, say, message_type='channel_archive_members')
 
             self.action("Archiving channel #{}".format(channel_name))
             payload = self.slacker.archive(channel_name)
@@ -231,7 +231,7 @@ class Destalinator(object):
             return False
 
         if self.destalinator_activated:
-            self.slackbot.say(channel_name, self.warning_text)
+            self.slacker.post_message(channel_name, self.warning_text, message_type='channel_warning')
             self.action("Warned #{}".format(channel_name))
 
         return True
@@ -271,5 +271,5 @@ class Destalinator(object):
         message += ", ".join(["#" + x for x in stale_channels])
         message = message.format(channel, being, there)
         if self.destalinator_activated:
-            self.slackbot.say(self.config.general_message_channel, message)
+            self.slacker.post_message(self.config.general_message_channel, message, message_type='warn_in_general')
         self.debug("Notified #{} with: {}".format(self.config.general_message_channel, message))

--- a/destalinator.py
+++ b/destalinator.py
@@ -226,7 +226,9 @@ class Destalinator(object):
 
         messages = self.get_messages(channel_name, days)
         texts = [x.get("text").strip() for x in messages if x.get("text")]
-        if not force_warn and self.add_slack_channel_markup(self.warning_text) in texts:
+        if (not force_warn and
+            (self.add_slack_channel_markup(self.warning_text) in texts or
+                any(any(a.get('fallback') == 'channel_warning' for a in m.get('attachments', [])) for m in messages))):
             self.debug("Not warning #{} because we found a prior warning".format(channel_name))
             return False
 

--- a/destalinator.py
+++ b/destalinator.py
@@ -254,7 +254,7 @@ class Destalinator(object):
             if self.stale(channel, days):
                 if self.warn(channel, days, force_warn):
                     stale.append(channel)
-        if stale:
+        if stale and self.config.general_message_channel:
             self.debug("Notifying #{} of warned channels".format(self.config.general_message_channel))
             self.warn_in_general(stale)
 

--- a/destalinator.py
+++ b/destalinator.py
@@ -206,9 +206,6 @@ class Destalinator(object):
         """Safe archive all channels stale longer than `days`."""
         self.action("Safe-archiving all channels stale for more than {} days".format(days))
         for channel in sorted(self.slacker.channels_by_name.keys()):
-            if self.ignore_channel(channel):
-                self.debug("Not archiving #{} because it's in ignore_channels".format(channel))
-                continue
             if self.stale(channel, days):
                 self.debug("Attempting to safe-archive #{}".format(channel))
                 self.safe_archive(channel)

--- a/flagger.py
+++ b/flagger.py
@@ -65,7 +65,7 @@ class Flagger(executor.Executor):
         """
         channel = config.control_channel
         if not self.slacker.channel_exists(channel):
-            self.ds.warning("Flagger control channel does not exist, cannot run. Please create #{}.".format(channel))
+            self.ds.logger.warning("Flagger control channel does not exist, cannot run. Please create #%s.", channel)
             return False
         cid = self.slacker.get_channelid(channel)
         messages = self.slacker.get_messages_in_time_range(0, cid, self.now)
@@ -76,7 +76,7 @@ class Flagger(executor.Executor):
             if tokens[0:3] != ['flag', 'content', 'rule']:
                 continue
             if len(tokens) < 5:
-                self.ds.warning("control message {} has too few tokens".format(text))
+                self.ds.logger.warning("Control message %s has too few tokens", text)
                 continue
             if len(tokens) == 5 and tokens[4] == 'delete':
                 uuid = tokens[3]
@@ -102,7 +102,7 @@ class Flagger(executor.Executor):
                 self.dprint(m)
                 self.dprint(tb)
                 if not self.debug:
-                    self.ds.warning(m)
+                    self.ds.logger.warning(m)
         self.control = control
         self.dprint("control: {}".format(json.dumps(self.control, indent=4)))
         self.emoji = [x['emoji'] for x in self.control.values()]
@@ -227,8 +227,12 @@ class Flagger(executor.Executor):
                     if not self.debug and self.destalinator_activated:
                         self.sb.say(output_channel["output"], m)
                 else:
-                    self.ds.warning("Attempted to announce in {} because of rule :{}:{}{}, but channel does not exist.".format(
-                            output_channel["output"], output_channel["emoji"], output_channel["comparator"], output_channel["threshold"]))
+                    self.ds.logger.warning("Attempted to announce in {} because of rule :{}:{}{}, but channel does not exist.".format(
+                        output_channel["output"],
+                        output_channel["emoji"],
+                        output_channel["comparator"],
+                        output_channel["threshold"]
+                    ))
 
     def flag(self):
         if self.initialize_control():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 APScheduler==3.0.5
 requests==2.9.1
 PyYAML==3.11
+mock==2.0.0
+six==1.10.0

--- a/slackbot.py
+++ b/slackbot.py
@@ -24,5 +24,5 @@ class Slackbot(object):
         if channel[0] == '#':
             channel = channel[1:]
         nurl = self.url + "?token={}&channel=%23{}".format(self.token, channel)
-        p = requests.post(nurl, statement)
+        p = requests.post(nurl, data=statement.encode('utf-8'))
         return p.status_code

--- a/slacker.py
+++ b/slacker.py
@@ -214,3 +214,25 @@ class Slacker(object):
         request = requests.get(url)
         payload = request.json()
         return payload
+
+    def post_message(self, channel, message, message_type=None):
+        """
+        Posts a `message` into a `channel`.
+        Optionally append an invisible attachment with 'fallback' set to `message_type`.
+
+        Note: `channel` value should not be preceded with '#'.
+        """
+        assert channel  # not blank
+        if channel[0] == '#':
+            channel = channel[1:]
+
+        post_data = {
+            'token': self.token,
+            'channel': channel,
+            'text': message.encode('utf-8')
+        }
+        if message_type:
+            post_data['attachments'] = json.dumps([{'fallback': message_type}], encoding='utf-8')
+
+        p = requests.post(self.url + "chat.postMessage", data=post_data)
+        return p.json()

--- a/tests/content_ascii.txt
+++ b/tests/content_ascii.txt
@@ -1,0 +1,1 @@
+Don't fear the reaper.

--- a/tests/content_unicode.txt
+++ b/tests/content_unicode.txt
@@ -1,0 +1,1 @@
+Don’t fear the reaper.

--- a/tests/test_destalinator.py
+++ b/tests/test_destalinator.py
@@ -300,44 +300,48 @@ class DestalinatorArchiveTestCase(unittest.TestCase):
     @mock.patch('tests.test_destalinator.SlackerMock')
     def test_skips_ignored_channel(self, mock_slacker):
         self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
-        self.slackbot.say = mock.MagicMock(return_value=200)
+        mock_slacker.post_message.return_value = {}
         mock_slacker.archive.return_value = {'ok': True}
         self.destalinator.config.ignore_channels = ['stalinists']
         self.destalinator.archive("stalinists")
-        self.assertFalse(self.slackbot.say.called)
+        self.assertFalse(mock_slacker.post_message.called)
 
     @mock.patch('tests.test_destalinator.SlackerMock')
     def test_skips_when_destalinator_not_activated(self, mock_slacker):
         self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=False)
-        self.slackbot.say = mock.MagicMock(return_value=200)
+        mock_slacker.post_message.return_value = {}
         self.destalinator.archive("stalinists")
-        self.assertFalse(self.slackbot.say.called)
+        self.assertFalse(mock_slacker.post_message.called)
 
     @mock.patch('tests.test_destalinator.SlackerMock')
     def test_announces_closure_with_closure_text(self, mock_slacker):
         self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
-        self.slackbot.say = mock.MagicMock(return_value=200)
+        mock_slacker.post_message.return_value = {}
         mock_slacker.archive.return_value = {'ok': True}
+        mock_slacker.get_channel_member_names.return_value = ['sridhar', 'jane']
         self.destalinator.archive("stalinists")
-        self.assertIn(mock.call('stalinists', self.destalinator.closure_text), self.slackbot.say.mock_calls)
+        self.assertIn(
+            mock.call('stalinists', mock.ANY, message_type='channel_archive'),
+            mock_slacker.post_message.mock_calls
+        )
 
     @mock.patch('tests.test_destalinator.SlackerMock')
     def test_announces_members_at_channel_closing(self, mock_slacker):
         self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
-        self.slackbot.say = mock.MagicMock(return_value=200)
+        mock_slacker.post_message.return_value = {}
         mock_slacker.archive.return_value = {'ok': True}
         names = ['sridhar', 'jane']
         mock_slacker.get_channel_member_names.return_value = names
         self.destalinator.archive("stalinists")
         self.assertIn(
-            mock.call('stalinists', MockValidator(lambda s: all(name in s for name in names))),
-            self.slackbot.say.mock_calls
+            mock.call('stalinists', MockValidator(lambda s: all(name in s for name in names)), message_type=mock.ANY),
+            mock_slacker.post_message.mock_calls
         )
 
     @mock.patch('tests.test_destalinator.SlackerMock')
     def test_calls_archive_method(self, mock_slacker):
         self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
-        self.slackbot.say = mock.MagicMock(return_value=200)
+        mock_slacker.post_message.return_value = {}
         mock_slacker.archive.return_value = {'ok': True}
         self.destalinator.archive("stalinists")
         mock_slacker.archive.assert_called_once_with('stalinists')
@@ -351,7 +355,7 @@ class DestalinatorSafeArchiveTestCase(unittest.TestCase):
     @mock.patch('tests.test_destalinator.SlackerMock')
     def test_skips_channel_with_only_restricted_users(self, mock_slacker):
         self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
-        self.slackbot.say = mock.MagicMock(return_value=200)
+        mock_slacker.post_message.return_value = {}
         mock_slacker.archive.return_value = {'ok': True}
         mock_slacker.channel_has_only_restricted_members.return_value = True
         self.destalinator.safe_archive("stalinists")
@@ -360,7 +364,7 @@ class DestalinatorSafeArchiveTestCase(unittest.TestCase):
     @mock.patch('tests.test_destalinator.SlackerMock')
     def test_skips_archiving_if_before_earliest_archive_date(self, mock_slacker):
         self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
-        self.slackbot.say = mock.MagicMock(return_value=200)
+        mock_slacker.post_message.return_value = {}
         self.destalinator.archive = mock.MagicMock(return_value=True)
         mock_slacker.channel_has_only_restricted_members.return_value = False
         today = datetime.date.today()
@@ -371,7 +375,7 @@ class DestalinatorSafeArchiveTestCase(unittest.TestCase):
     @mock.patch('tests.test_destalinator.SlackerMock')
     def test_calls_archive_method(self, mock_slacker):
         self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
-        self.slackbot.say = mock.MagicMock(return_value=200)
+        mock_slacker.post_message.return_value = {}
         self.destalinator.archive = mock.MagicMock(return_value=True)
         mock_slacker.channel_has_only_restricted_members.return_value = False
         self.destalinator.safe_archive("stalinists")

--- a/tests/test_destalinator.py
+++ b/tests/test_destalinator.py
@@ -1,0 +1,285 @@
+import mock
+import os
+import unittest
+
+import destalinator
+import slacker
+import slackbot
+
+
+sample_slack_messages = [
+    {
+        "type": "message",
+        "channel": "C2147483705",
+        "user": "U2147483697",
+        "text": "Human human human.",
+        "ts": "1355517523.000005",
+        "edited": {
+            "user": "U2147483697",
+            "ts": "1355517536.000001"
+        }
+    },
+    {
+        "type": "message",
+        "subtype": "bot_message",
+        "text": "Robot robot robot.",
+        "ts": "1403051575.000407",
+        "user": "U023BEAD1"
+    },
+    {
+        "type": "message",
+        "subtype": "channel_name",
+        "text": "#stalin has been renamed <C2147483705|khrushchev>",
+        "ts": "1403051575.000407",
+        "user": "U023BECGF"
+    },
+    {
+        "type": "message",
+        "channel": "C2147483705",
+        "user": "U2147483697",
+        "text": "Contemplating existence.",
+        "ts": "1355517523.000005"
+    },
+    {
+        "type": "message",
+        "subtype": "bot_message",
+        "attachments": [
+            {
+                "fallback": "Required plain-text summary of the attachment.",
+                "color": "#36a64f",
+                "pretext": "Optional text that appears above the attachment block",
+                "author_name": "Bobby Tables",
+                "author_link": "http://flickr.com/bobby/",
+                "author_icon": "http://flickr.com/icons/bobby.jpg",
+                "title": "Slack API Documentation",
+                "title_link": "https://api.slack.com/",
+                "text": "Optional text that appears within the attachment",
+                "fields": [
+                    {
+                        "title": "Priority",
+                        "value": "High",
+                        "short": False
+                    }
+                ],
+                "image_url": "http://my-website.com/path/to/image.jpg",
+                "thumb_url": "http://example.com/path/to/thumb.png",
+                "footer": "Slack API",
+                "footer_icon": "https://platform.slack-edge.com/img/default_application_icon.png",
+                "ts": 123456789
+            }
+        ],
+        "ts": "1403051575.000407",
+        "user": "U023BEAD1"
+    }
+]
+
+
+class SlackerMock(slacker.Slacker):
+    def get_users(self):
+        pass
+
+    def get_channels(self):
+        pass
+
+
+class DestalinatorChannelMarkupTestCase(unittest.TestCase):
+    def setUp(self):
+        self.slacker = SlackerMock("testing", "token")
+        self.slackbot = slackbot.Slackbot("testing", "token")
+
+    @mock.patch('tests.test_destalinator.SlackerMock')
+    def test_add_slack_channel_markup(self, mock_slacker):
+        self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
+        input_text = "Please find my #general channel reference."
+        mock_slacker.add_channel_markup.return_value = "<#ABC123|general>"
+        self.assertEqual(
+            self.destalinator.add_slack_channel_markup(input_text),
+            "Please find my <#ABC123|general> channel reference."
+        )
+
+    @mock.patch('tests.test_destalinator.SlackerMock')
+    def test_add_slack_channel_markup_multiple(self, mock_slacker):
+        self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
+        input_text = "Please find my #general multiple #general channel #general references."
+        mock_slacker.add_channel_markup.return_value = "<#ABC123|general>"
+        self.assertEqual(
+            self.destalinator.add_slack_channel_markup(input_text),
+            "Please find my <#ABC123|general> multiple <#ABC123|general> channel <#ABC123|general> references."
+        )
+
+    @mock.patch('tests.test_destalinator.SlackerMock')
+    def test_add_slack_channel_markup_hyphens(self, mock_slacker):
+        self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
+        input_text = "Please find my #channel-with-hyphens references."
+        mock_slacker.add_channel_markup.return_value = "<#EXA456|channel-with-hyphens>"
+        self.assertEqual(
+            self.destalinator.add_slack_channel_markup(input_text),
+            "Please find my <#EXA456|channel-with-hyphens> references."
+        )
+
+    @mock.patch('tests.test_destalinator.SlackerMock')
+    def test_add_slack_channel_markup_ignore_screaming(self, mock_slacker):
+        self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
+        input_text = "Please find my #general channel reference and ignore my #HASHTAGSCREAMING thanks."
+        mock_slacker.add_channel_markup.return_value = "<#ABC123|general>"
+        self.assertEqual(
+            self.destalinator.add_slack_channel_markup(input_text),
+            "Please find my <#ABC123|general> channel reference and ignore my #HASHTAGSCREAMING thanks."
+        )
+
+
+class DestalinatorChannelMinimumAgeTestCase(unittest.TestCase):
+    def setUp(self):
+        self.slacker = SlackerMock("testing", "token")
+        self.slackbot = slackbot.Slackbot("testing", "token")
+
+    @mock.patch('tests.test_destalinator.SlackerMock')
+    def test_channel_is_old(self, mock_slacker):
+        self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
+        mock_slacker.get_channel_info.return_value = {'age': 86400 *  60}
+        self.assertTrue(self.destalinator.channel_minimum_age("testing", 30))
+
+    @mock.patch('tests.test_destalinator.SlackerMock')
+    def test_channel_is_exactly_expected_age(self, mock_slacker):
+        self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
+        mock_slacker.get_channel_info.return_value = {'age': 86400 *  30}
+        self.assertFalse(self.destalinator.channel_minimum_age("testing", 30))
+
+    @mock.patch('tests.test_destalinator.SlackerMock')
+    def test_channel_is_young(self, mock_slacker):
+        self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
+        mock_slacker.get_channel_info.return_value = {'age': 86400 *  1}
+        self.assertFalse(self.destalinator.channel_minimum_age("testing", 30))
+
+
+class DestalinatorGetMessagesTestCase(unittest.TestCase):
+    def setUp(self):
+        self.slacker = SlackerMock("testing", "token")
+        self.slackbot = slackbot.Slackbot("testing", "token")
+
+    @mock.patch('tests.test_destalinator.SlackerMock')
+    def test_with_default_included_subtypes(self, mock_slacker):
+        self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
+        mock_slacker.get_channelid.return_value = "123456"
+        mock_slacker.get_messages_in_time_range.return_value = sample_slack_messages
+        self.assertEquals(len(self.destalinator.get_messages("general", 30)), 5)
+
+    @mock.patch('tests.test_destalinator.SlackerMock')
+    def test_with_empty_included_subtypes(self, mock_slacker):
+        self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
+        self.destalinator.config.included_subtypes = []
+        mock_slacker.get_channelid.return_value = "123456"
+        mock_slacker.get_messages_in_time_range.return_value = sample_slack_messages
+        self.assertEquals(len(self.destalinator.get_messages("general", 30)), 2)
+
+    @mock.patch('tests.test_destalinator.SlackerMock')
+    def test_with_limited_included_subtypes(self, mock_slacker):
+        self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
+        self.destalinator.config.included_subtypes = ['bot_message']
+        mock_slacker.get_channelid.return_value = "123456"
+        mock_slacker.get_messages_in_time_range.return_value = sample_slack_messages
+        self.assertEquals(len(self.destalinator.get_messages("general", 30)), 4)
+
+
+class DestalinatorGetStaleChannelsTestCase(unittest.TestCase):
+    def setUp(self):
+        self.slacker = SlackerMock("testing", "token")
+        self.slackbot = slackbot.Slackbot("testing", "token")
+
+    @mock.patch('tests.test_destalinator.SlackerMock')
+    def test_with_no_stale_channels_but_all_minimum_age_with_default_ignore_users(self, mock_slacker):
+        self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
+        mock_slacker.channels_by_name = {'leninists': {'id': 'ABC4321'}, 'stalinists': {'id': 'ABC4321'}}
+        mock_slacker.get_channel_info.return_value = {'age': 60 * 86400}
+        self.destalinator.get_messages = mock.MagicMock(return_value=sample_slack_messages)
+        self.assertEqual(len(self.destalinator.get_stale_channels(30)), 0)
+
+    @mock.patch('tests.test_destalinator.SlackerMock')
+    def test_with_no_stale_channels_but_all_minimum_age_with_specific_ignore_users(self, mock_slacker):
+        self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
+        self.destalinator.config.ignore_users = ['U023BEAD1', 'U023BECGF', 'U2147483697']
+        mock_slacker.channels_by_name = {'leninists': {'id': 'ABC4321'}, 'stalinists': {'id': 'ABC4321'}}
+        mock_slacker.get_channel_info.return_value = {'age': 60 * 86400}
+        self.destalinator.get_messages = mock.MagicMock(return_value=sample_slack_messages)
+        self.assertEqual(len(self.destalinator.get_stale_channels(30)), 2)
+
+
+class DestalinatorIgnoreChannelTestCase(unittest.TestCase):
+    def setUp(self):
+        self.slacker = SlackerMock("testing", "token")
+        self.slackbot = slackbot.Slackbot("testing", "token")
+
+    def test_with_explicit_ignore_channel(self):
+        self.destalinator = destalinator.Destalinator(self.slacker, self.slackbot, activated=True)
+        self.destalinator.config.ignore_channels = ['stalinists']
+        self.assertTrue(self.destalinator.ignore_channel('stalinists'))
+
+    def test_with_matching_ignore_channel_pattern(self):
+        self.destalinator = destalinator.Destalinator(self.slacker, self.slackbot, activated=True)
+        self.destalinator.config.ignore_channel_patterns = ['^stal']
+        self.assertTrue(self.destalinator.ignore_channel('stalinists'))
+
+    @mock.patch('tests.test_destalinator.SlackerMock')
+    def test_with_non_mathing_ignore_channel_pattern(self, mock_slacker):
+        self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
+        self.destalinator.config.ignore_channel_patterns = ['^len']
+        self.assertFalse(self.destalinator.ignore_channel('stalinists'))
+
+    def test_with_many_matching_ignore_channel_patterns(self):
+        self.destalinator = destalinator.Destalinator(self.slacker, self.slackbot, activated=True)
+        self.destalinator.config.ignore_channel_patterns = ['^len', 'lin', '^st']
+        self.assertTrue(self.destalinator.ignore_channel('stalinists'))
+
+    def test_with_empty_ignore_channel_config(self):
+        self.destalinator = destalinator.Destalinator(self.slacker, self.slackbot, activated=True)
+        self.destalinator.config.ignore_channels = []
+        self.destalinator.config.ignore_channel_patterns = []
+        self.assertFalse(self.destalinator.ignore_channel('stalinists'))
+
+
+class DestalinatorStaleTestCase(unittest.TestCase):
+    def setUp(self):
+        self.slacker = SlackerMock("testing", "token")
+        self.slackbot = slackbot.Slackbot("testing", "token")
+
+    @mock.patch('tests.test_destalinator.SlackerMock')
+    def test_with_all_sample_messages(self, mock_slacker):
+        self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
+        mock_slacker.get_channel_info.return_value = {'age': 60 * 86400}
+        self.destalinator.get_messages = mock.MagicMock(return_value=sample_slack_messages)
+        self.assertFalse(self.destalinator.stale('stalinists', 30))
+
+    @mock.patch('tests.test_destalinator.SlackerMock')
+    def test_with_all_users_ignored(self, mock_slacker):
+        self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
+        self.destalinator.config.ignore_users = ['U023BEAD1', 'U023BECGF', 'U2147483697']
+        mock_slacker.get_channel_info.return_value = {'age': 60 * 86400}
+        self.destalinator.get_messages = mock.MagicMock(return_value=sample_slack_messages)
+        self.assertTrue(self.destalinator.stale('stalinists', 30))
+
+    @mock.patch('tests.test_destalinator.SlackerMock')
+    def test_with_only_a_dolphin_message(self, mock_slacker):
+        self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
+        mock_slacker.get_channel_info.return_value = {'age': 60 * 86400}
+        messages = [
+            {
+                "type": "message",
+                "channel": "C2147483705",
+                "user": "U2147483697",
+                "text": ":dolphin:",
+                "ts": "1355517523.000005"
+            }
+        ]
+        self.destalinator.get_messages = mock.MagicMock(return_value=messages)
+        self.assertTrue(self.destalinator.stale('stalinists', 30))
+
+    @mock.patch('tests.test_destalinator.SlackerMock')
+    def test_with_only_an_attachment_message(self, mock_slacker):
+        self.destalinator = destalinator.Destalinator(mock_slacker, self.slackbot, activated=True)
+        mock_slacker.get_channel_info.return_value = {'age': 60 * 86400}
+        self.destalinator.get_messages = mock.MagicMock(return_value=[m for m in sample_slack_messages if m.has_key('attachments')])
+        self.assertFalse(self.destalinator.stale('stalinists', 30))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,17 @@
+# encoding: utf-8
+
+import mock
+import unittest
+
+import utils
+
+class UtilsGetLocalFileContentTestCase(unittest.TestCase):
+    def test_unicode_file_content(self):
+        content = utils.get_local_file_content("tests/content_unicode.txt")
+        self.assertTrue(isinstance(content, unicode))
+        self.assertIn(u'’', content)
+
+    def test_ascii_file_content(self):
+        content = utils.get_local_file_content("tests/content_ascii.txt")
+        self.assertTrue(isinstance(content, unicode))
+        self.assertIn(u"'", content)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,8 @@
+import codecs
+
+def get_local_file_content(file_name):
+    """Read the contents of `file_name` into a unicode string, return the unicode string."""
+    f = codecs.open(file_name, encoding='utf-8')
+    ret = f.read().strip()
+    f.close()
+    return ret


### PR DESCRIPTION
Start organizing the code base more, and add unit tests.

Also switch to posting as the Slacker bot, rather than via slackbot’s incoming webhook integration.