### PR TITLE
Load the archive date cutoff from the environment

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -16,14 +16,15 @@ destalinator_activated_env_varname: DESTALINATOR_ACTIVATED
 # Name of environment variable determining whether output debug mode is enabled
 output_debug_env_varname: DESTALINATOR_SLACK_VERBOSE
 
+# Name of environment variable for the earliest date to archive stale channels.
+# If this is set, it should be of the form "yyyy-mm-dd" (e.g. "2017-02-19").
+earliest_archive_date_env_varname: EARLIEST_ARCHIVE_DATE
+
 # Days of silence before we warn a channel it's going to be archived
 warn_threshold: 30
 
 # Days of silence before we auto-archive a channel
 archive_threshold: 60
-
-# Do not archive before this date
-earliest_archive_date: "2016-01-28"
 
 # Where should we post "general" announcement messages?
 general_message_channel: "general"

--- a/destalinator.py
+++ b/destalinator.py
@@ -12,6 +12,10 @@ import config
 import slackbot
 
 
+# An arbitrary past date, as a default value for the earliest archive date
+PAST_DATE = datetime.date(2000, 1, 1)
+
+
 class Destalinator(object):
 
     closure_text_fname = "closure.txt"
@@ -34,7 +38,14 @@ class Destalinator(object):
         print("output_debug_to_slack_flag is {}".format(self.output_debug_to_slack_flag))
         self.destalinator_activated = activated
         print("destalinator_activated is {}".format(self.destalinator_activated))
-        self.earliest_archive_date = self.config.earliest_archive_date
+
+        archive_date_string = os.getenv(self.config.earliest_archive_date_env_varname)
+        if archive_date_string:
+            year, month, day = [int(x) for x in archive_date_string.split("-")]
+            self.earliest_archive_date = datetime.date(year, month, day)
+        else:
+            self.earliest_archive_date = PAST_DATE
+
         self.cache = {}
         self.now = int(time.time())
 
@@ -66,9 +77,7 @@ class Destalinator(object):
             return
 
         today = datetime.date.today()
-        year, month, day = [int(x) for x in self.earliest_archive_date.split("-")]
-        earliest = datetime.date(year, month, day)
-        if today >= earliest:
+        if today >= self.earliest_archive_date:
             self.action("Archiving channel {}".format(channel_name))
             self.archive(channel_name)
         else:

--- a/destalinator.py
+++ b/destalinator.py
@@ -13,7 +13,7 @@ import slackbot
 
 
 # An arbitrary past date, as a default value for the earliest archive date
-PAST_DATE = datetime.date(2000, 1, 1)
+PAST_DATE_STRING = '2000-01-01'
 
 
 class Destalinator(object):
@@ -39,12 +39,10 @@ class Destalinator(object):
         self.destalinator_activated = activated
         print("destalinator_activated is {}".format(self.destalinator_activated))
 
-        archive_date_string = os.getenv(self.config.earliest_archive_date_env_varname)
-        if archive_date_string:
-            year, month, day = [int(x) for x in archive_date_string.split("-")]
-            self.earliest_archive_date = datetime.date(year, month, day)
-        else:
-            self.earliest_archive_date = PAST_DATE
+        archive_date_string = (os.getenv(self.config.earliest_archive_date_env_varname)
+                               or PAST_DATE_STRING)
+        year, month, day = [int(x) for x in archive_date_string.split("-")]
+        self.earliest_archive_date = datetime.date(year, month, day)
 
         self.cache = {}
         self.now = int(time.time())


### PR DESCRIPTION
Instead of having this setting in `configuration.yaml` (forcing anyone wanting to use it on their own system to edit the file and redeploy), we can read it in from the environment.

In the case where the environment variable is not set, I'm taking that to mean that stale channels can be archived no matter the current date. Given the old value set in the config file is now in the past, this effectively doesn't change the behaviour.

I've made a few changes at the point this config value is used, so that it gets parsed at the point of construction rather than the point of use. This was mostly for clean-up purposes, but has the added benefit of causing the code to error out earlier if it's given an invalid value.

There's one point where this date gets passed directly into a `format` call, but that produces the same value as before.