### PR TITLE
Simplify archive date fallback code

### DIFF
--- a/destalinator.py
+++ b/destalinator.py
@@ -81,7 +81,7 @@ class Destalinator(object):
 
     def get_earliest_archive_date(self):
         """Return a datetime.date object representing the earliest archive date."""
-        date_string = os.getenv(self.config.get('earliest_archive_date_env_varname', '')) \
+        date_string = os.getenv(self.config.get('earliest_archive_date_env_varname') or '') \
             or self.config.get('earliest_archive_date') \
             or PAST_DATE_STRING
         return datetime.strptime(date_string, "%Y-%m-%d").date()

--- a/destalinator.py
+++ b/destalinator.py
@@ -81,11 +81,7 @@ class Destalinator(object):
 
     def get_earliest_archive_date(self):
         """Return a datetime.date object representing the earliest archive date."""
-        date_string = \
-            ( \
-                self.config.get('earliest_archive_date_env_varname') \
-                and os.getenv(self.config.get('earliest_archive_date_env_varname')) \
-            ) \
+        date_string = os.getenv(self.config.get('earliest_archive_date_env_varname', '')) \
             or self.config.get('earliest_archive_date') \
             or PAST_DATE_STRING
         return datetime.strptime(date_string, "%Y-%m-%d").date()


### PR DESCRIPTION
Easier to soothe Python 3.6 with a string than go through the multi-step existence check.