### PR TITLE
Log messages to a Slack channel if you want

### DIFF
--- a/announcer.py
+++ b/announcer.py
@@ -37,7 +37,7 @@ class Announcer(executor.Executor):
             m = "Channel #{} was created by @{} with purpose: {}".format(cname, creator, purpose)
             if self.destalinator_activated:
                 if self.slacker.channel_exists(config.announce_channel):
-                    self.sb.say(config.announce_channel, m)
+                    self.slackbot.say(config.announce_channel, m)
                 else:
                     self.ds.logger.warning("Attempted to announce in %s, but channel does not exist.", config.announce_channel)
             self.logger.info("ANNOUNCE: {}".format(m))

--- a/executor.py
+++ b/executor.py
@@ -19,19 +19,23 @@ class Executor(object):
         slackbot_token = os.getenv(self.config.slackbot_api_token_env_varname)
         api_token = os.getenv(self.config.api_token_env_varname)
 
+        self.slackbot = slackbot.Slackbot(config.SLACK_NAME, token=slackbot_token)
+
         self.logger = logging.getLogger(__name__)
-        utils.set_up_logger(self.logger, log_level_env_var='DESTALINATOR_LOG_LEVEL')
+        utils.set_up_logger(self.logger,
+                            log_level_env_var='DESTALINATOR_LOG_LEVEL',
+                            log_to_slack_env_var='DESTALINATOR_LOG_TO_CHANNEL',
+                            log_channel=self.config.log_channel,
+                            slackbot=self.slackbot)
 
         self.destalinator_activated = False
         if os.getenv(self.config.destalinator_activated_env_varname):
             self.destalinator_activated = True
         self.logger.debug("destalinator_activated is %s", self.destalinator_activated)
 
-        self.sb = slackbot.Slackbot(config.SLACK_NAME, token=slackbot_token)
-
         self.slacker = slacker.Slacker(config.SLACK_NAME, token=api_token, logger=self.logger)
 
         self.ds = destalinator.Destalinator(slacker=self.slacker,
-                                            slackbot=self.sb,
+                                            slackbot=self.slackbot,
                                             activated=self.destalinator_activated,
                                             logger=self.logger)

--- a/flagger.py
+++ b/flagger.py
@@ -222,7 +222,7 @@ class Flagger(executor.Executor):
                     md = "Saying {} to {}".format(m, output_channel["output"])
                     self.logger.debug(md)
                     if not self.debug and self.destalinator_activated:
-                        self.sb.say(output_channel["output"], m)
+                        self.slackbot.say(output_channel["output"], m)
                 else:
                     self.ds.logger.warning("Attempted to announce in {} because of rule :{}:{}{}, but channel does not exist.".format(
                         output_channel["output"],

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -3,6 +3,27 @@ import logging
 import os
 
 
+class SlackHandler(logging.Handler):
+    """
+    A logging.Handler subclass for logging messages into a Slack channel.
+
+    See also: https://docs.python.org/3/library/logging.html#handler-objects
+    """
+    def __init__(self, slackbot, log_channel, level):
+        """
+        `slackbot` is an initialized Slackbot() object
+        `log_channel` is the name of a channel that should receive log messages
+        `level` is the log level to use for logging to the Slack channel
+        """
+        super(self.__class__, self).__init__(level)  # pylint: disable=E1003
+        self.slackbot = slackbot
+        self.log_channel = log_channel
+
+    def emit(self, record):
+        """Do whatever it takes to actually log the specified logging record."""
+        self.slackbot.say(self.log_channel, record.getMessage())
+
+
 def get_local_file_content(file_name):
     """Read the contents of `file_name` into a unicode string, return the unicode string."""
     f = codecs.open(file_name, encoding='utf-8')
@@ -11,17 +32,29 @@ def get_local_file_content(file_name):
     return ret
 
 
-def set_up_logger(logger, log_level_env_var=None, log_to_slack_env_var=None, log_channel=None, default_level='INFO'):
+def set_up_logger(logger,
+                  log_level_env_var=None,
+                  log_to_slack_env_var=None,
+                  log_channel=None,
+                  default_level='INFO',
+                  slackbot=None):
     """
     Sets up a handler and formatter on a given `logging.Logger` object.
 
     * `log_level_env_var` - Grabs logging level from this ENV var. Possible values are standard: "debug", "error", etc.
-    * `log_to_slack_env_var` - FUTURE - Will point to an ENV var that indicates whether to log to a Slack channel.
-    * `log_channel` - FUTURE - Will indicate the name of the Slack channel to which we'll send logs.
+    * `log_to_slack_env_var` - Points to an ENV var that indicates whether to log to a Slack channel.
+    * `log_channel` - Indicates the name of the Slack channel to which we'll send logs.
     * `default_level` - The default log level if one is not set in the environment.
+    * `slackbot` - A slackbot.Slackbot() object ready to send messages to a Slack channel.
     """
     logger.setLevel(getattr(logging, os.getenv(log_level_env_var, default_level).upper(), getattr(logging, default_level)))
     stream_handler = logging.StreamHandler()
     formatter = logging.Formatter('%(asctime)s [%(levelname)s]: %(message)s')
     stream_handler.setFormatter(formatter)
     logger.addHandler(stream_handler)
+
+    if os.getenv(log_to_slack_env_var) and log_channel and slackbot:
+        logger.debug("Logging to slack channel: %s", log_channel)
+        slack_handler = SlackHandler(slackbot=slackbot, log_channel=log_channel, level=logger.getEffectiveLevel())
+        slack_handler.setFormatter(formatter)
+        logger.addHandler(slack_handler)


### PR DESCRIPTION
Re-implements Slack channel logging via `logging.Handler()`.

Note that it will obey the log level you set with the `DESTALINATOR_LOG_LEVEL` environment variable. So, leave the default at `"info"` unless you want a ton of log messages in your Slack log channel.