### PR TITLE
Fix for flagged bot message without text

### DIFF
--- a/flagger.py
+++ b/flagger.py
@@ -28,8 +28,8 @@ class Flagger(executor.Executor):
                  '>=': operator.ge, '<=': operator.le}
 
     def __init__(self, *args, **kwargs):
+        self.debug = kwargs.pop('debug', False)
         super(self.__class__, self).__init__(*args, **kwargs)
-        self.debug = kwargs.get('debug')
         self.now = int(time.time())
 
     def extract_threshold(self, token):

--- a/flagger.py
+++ b/flagger.py
@@ -146,25 +146,18 @@ class Flagger(executor.Executor):
         reactions = message.get("reactions")
         emoji_set = set(self.emoji)
         current_reactions = {}
-        t = message.get("text")
-        if t.find("SVP") != -1:
-            def d(p):
-                pass
-        else:
-            def d(p):
-                pass
-        d("reactions: {}".format(reactions))
-        d("emoji_equivalents:\n{}".format(json.dumps(self.emoji_equivalents, indent=4)))
+        self.logger.debug("reactions: %s", reactions)
+        self.logger.debug("emoji_equivalents:\n%s", json.dumps(self.emoji_equivalents, indent=4))
         if "floppy_disk" in self.emoji_equivalents.keys():
-            d("floppy_disk: {}".format(self.emoji_equivalents['floppy_disk']))
+            self.logger.debug("floppy_disk: %s", self.emoji_equivalents['floppy_disk'])
         for reaction in reactions:
             count = reaction['count']
             current_emoji = reaction['name']
-            d("current_emoji: {}".format(current_emoji))
+            self.logger.debug("current_emoji: %s", current_emoji)
             equivalents = copy.copy(self.emoji_equivalents.get(current_emoji, []))
-            d("equivalents = {}".format(equivalents))
+            self.logger.debug("equivalents: %s", equivalents)
             equivalents.append(current_emoji)
-            d("equivalents = {}".format(equivalents))
+            self.logger.debug("equivalents: %s", equivalents)
             current_set = set(equivalents)
             i = current_set.intersection(emoji_set)
             if not i:
@@ -172,7 +165,7 @@ class Flagger(executor.Executor):
             for ce in equivalents:
                 current_reactions[ce] = current_reactions.get(ce, 0) + count
             # if we're here, at least one emoji matches (but count may still not be right)
-        d("Current reactions: {}".format(current_reactions))
+        self.logger.debug("Current reactions: {}".format(current_reactions))
         for uuid in self.control:
             rule = self.control[uuid]
             for ce in current_reactions:

--- a/tests/test_destalinator.py
+++ b/tests/test_destalinator.py
@@ -448,7 +448,7 @@ class DestalinatorSafeArchiveTestCase(unittest.TestCase):
         self.destalinator.archive = mock.MagicMock(return_value=True)
         mock_slacker.channel_has_only_restricted_members.return_value = False
         today = date.today()
-        self.destalinator.earliest_archive_date = today.replace(day=today.day + 1)
+        self.destalinator.earliest_archive_date = today + timedelta(days=1)
         self.destalinator.safe_archive("stalinists")
         self.assertFalse(self.destalinator.archive.called)
 


### PR DESCRIPTION
We had a message that stopped the flagger, and threw this error:

```AttributeError: 'NoneType' object has no attribute 'find'
  File "scheduler.py", line 35, in destalinate_job
    flagger.Flagger().flag()
  File "/app/flagger.py", line 233, in flag
    self.announce_interesting_messages()
  File "/app/flagger.py", line 205, in announce_interesting_messages
    messages = self.get_interesting_messages()
  File "/app/flagger.py", line 199, in get_interesting_messages
    announce = self.message_destination(message)
  File "/app/flagger.py", line 150, in message_destination
    if t.find("SVP") != -1:```

It was a bot message that didn't have the "text" key, so, t.find failed.

Merging into work slack and testing there. 