### PR TITLE
Add Docker build steps to the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+sudo: required
+
+services:
+  - docker
+
 language: python
 
 python:
@@ -10,3 +15,11 @@ install:
 
 script:
   - python -m unittest discover -f
+
+deploy:
+  provider: script
+  skip_cleanup: true
+  script: chmod +x docker-deploy.sh && sh $TRAVIS_BUILD_DIR/docker-deploy.sh
+  on:
+    tags: true
+    repo: randsleadershipslack/destalinator

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ You'll also need to change `configuration.yaml` appropriately. `warner.py` and `
 
 That said, if you're running on Heroku, you can create a single `clock` process that runs `python scheduler.py`.
 
+### Docker
+You can also use the prebuilt Docker image at [randsleadershipslack/destalinator](https://hub.docker.com/r/randsleadershipslack/destalinator/).
+
 ## Components
 
 ### Warner

--- a/docker-deploy.sh
+++ b/docker-deploy.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+docker build -t randsleadershipslack/destalinator .;
+docker tag randsleadershipslack/destalinator randsleadershipslack/destalinator:$TRAVIS_TAG;
+docker push randsleadershipslack/destalinator:latest;
+docker push randsleadershipslack/destalinator:$TRAVIS_TAG;


### PR DESCRIPTION
Auto-deploy a new Docker images when a git tag is pushed. You'll need to create the Docker Hub repo `randsleadershipslack/destalinator` and add the env vars `DOCKER_USERNAME` and `DOCKER_PASSWORD` to the Travis build.

It will end up looking like https://hub.docker.com/r/theconnman/destalinator.