### PR TITLE
Instantiate the NullHandler

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
 import logging
 
 # No logging for tests:
-logging.getLogger().addHandler(logging.NullHandler)
+logging.getLogger().addHandler(logging.NullHandler())


### PR DESCRIPTION
For some reason (likely since slack logging also uses handlers) this wasn't erring except in certain cases when I was mucking w. Slack logging. But this makes the tests more reliable.