### PR TITLE
Sleep for slack

### DIFF
--- a/slacker.py
+++ b/slacker.py
@@ -230,7 +230,7 @@ class Slacker(WithLogger, WithConfig):
 
     def post(self, *args, **kwargs):
         self.sleep_for_slack()
-        self.session.post(*args, **kwargs)
+        return self.session.post(*args, **kwargs)
 
     def archive(self, channel_name):
         url_template = self.url + "channels.archive?token={}&channel={}"


### PR DESCRIPTION
This addresses the following:

> In general we allow applications that integrate with Slack to send no more than one message per second.

From: https://api.slack.com/docs/rate-limits

Thanks, @katherinelim!

This does not fix #132 completely, as we're still making more requests than necessary, but should mean we do not have to do the rate limit sleeps.