### PR TITLE
add calibrate to ignore_channel_patterns

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -39,6 +39,7 @@ ignore_channels:
 ignore_channel_patterns:
   - ^zmeta-
   - rands
+  - calibrate
 
 # Users to ignore when considering if a channel is stale
 ignore_users:


### PR DESCRIPTION
Calibrate is an annual conference since 2015; #calibrate Slack channel is where discussions happen yearly.

Co-Authored-By: Mason Jones @masonoise