### PR TITLE
add theleaddeveloper to ignore_channel_patterns

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -40,6 +40,7 @@ ignore_channel_patterns:
   - ^zmeta-
   - rands
   - calibrate
+  - theleaddeveloper
 
 # Users to ignore when considering if a channel is stale
 ignore_users:


### PR DESCRIPTION
The Lead Developer is a conference that happens multiple times a year in different locations; discussions happen periodically in #theleaddeveloper Slack channel.