### PR TITLE
Pagination and logging fixes

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -1,4 +1,5 @@
 import logging
+import traceback
 
 from apscheduler.schedulers.blocking import BlockingScheduler
 from raven.base import Client as RavenClient
@@ -41,7 +42,7 @@ def destalinate_job():
         except Exception as e:  # pylint: disable=W0703
             raven_client.captureException()
             if not get_config().sentry_dsn:
-                raise e
+                raise traceback.format_exc()
     logging.info("END: destalinate_job")
 
 

--- a/utils/slack_logging.py
+++ b/utils/slack_logging.py
@@ -20,7 +20,7 @@ class SlackHandler(logging.Handler, WithLogger):
 
     def emit(self, record):
         """Do whatever it takes to actually log the specified logging record."""
-        self.slackbot.say(self.config.log_channel, record.getMessage())
+        self.slackbot.say(get_config().log_channel, record.getMessage())
 
 
 def set_up_slack_logger(slackbot=None):
@@ -35,7 +35,7 @@ def set_up_slack_logger(slackbot=None):
     """
     logger = logging.getLogger()
 
-    if logger.handlers:
+    if len(logger.handlers) > 1:
         # We've likely already ran through the rest of this method:
         return
 


### PR DESCRIPTION
fixes #119, fixes #182 

- Added pagination to the `users.list` and `channels.list` functions
- Ensured nested traceback to console when not using Sentry
- Repaired the logging handler to account for the default handler causing the intended handlers not being initialized and `config` missing from the namespace