### PR TITLE
handle slack channels shared with other teams

### DIFF
--- a/slacker.py
+++ b/slacker.py
@@ -221,6 +221,9 @@ class Slacker(WithLogger, WithConfig):
         returns an array of ["@member"] for members of the channel
         """
         members = self.get_channel_members_ids(channel_name)
+        # Need to check if user is in users_by_id because a channel may be shared
+        # across Slack teams and the other Slack team's members would not be in
+        # this Slack team's user/member list.
         return ["@" + self.users_by_id[x] for x in members if x in self.users_by_id]
 
     def get_channel_info(self, channel_name):

--- a/slacker.py
+++ b/slacker.py
@@ -221,7 +221,7 @@ class Slacker(WithLogger, WithConfig):
         returns an array of ["@member"] for members of the channel
         """
         members = self.get_channel_members_ids(channel_name)
-        return ["@" + self.users_by_id[x] for x in members]
+        return ["@" + self.users_by_id[x] for x in members if x in self.users_by_id]
 
     def get_channel_info(self, channel_name):
         """


### PR DESCRIPTION
Added a check to see if user is in users_by_id because a channel may be shared across Slack teams and the other Slack team's members would not be in this Slack team's user/member list.

Thanks @royrapoport for style suggestion.